### PR TITLE
Add conversation history panel with event detail view

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,8 +2,12 @@
 
 import json
 import os
+import re
+import sqlite3
 import subprocess
 import time
+from pathlib import Path
+
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 
@@ -214,6 +218,143 @@ def git_status():
         return jsonify({"error": "Git not found"}), 500
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+CODEX_HOME = Path.home() / ".codex"
+STATE_DB = CODEX_HOME / "state_5.sqlite"
+LOGS_DB = CODEX_HOME / "logs_1.sqlite"
+
+
+def _parse_log_body(body, level):
+    """Parse a feedback_log_body string into a typed conversation entry.
+
+    Returns a dict with keys (type, content) or None if the entry should
+    be skipped (internal noise).
+    """
+    if not body:
+        return None
+
+    # Extract the human-readable part after the last span closure ": "
+    # Format: "span{key=val}:span{...}: <message>"
+    msg = body
+    colon_idx = body.rfind("}: ")
+    if colon_idx >= 0:
+        msg = body[colon_idx + 3:].strip()
+
+    if not msg:
+        return None
+
+    # Classify the message into a conversation event type
+    # ToolCall events
+    tool_match = re.match(r"ToolCall:\s*(\S+)\s*(.*)", msg, re.DOTALL)
+    if tool_match:
+        tool_name = tool_match.group(1)
+        tool_args = tool_match.group(2).strip()
+        # Try to pretty-print JSON args
+        if tool_args.startswith("{"):
+            try:
+                parsed = json.loads(tool_args.split(" thread_id=")[0])
+                tool_args = json.dumps(parsed, indent=2)
+            except (json.JSONDecodeError, IndexError):
+                pass
+        content = f"{tool_name}: {tool_args}" if tool_args else tool_name
+        return {"type": "tool", "content": content}
+
+    # Shutdown / lifecycle events
+    if "Shutting down" in msg:
+        return {"type": "info", "content": msg}
+
+    # User input operations
+    if "codex.op=\"user_input\"" in body or "op.dispatch.user_input" in body:
+        # Only surface if the message itself is meaningful
+        if msg and "cache" not in msg.lower():
+            return {"type": "user", "content": msg}
+
+    # Error / warning level entries
+    if level in ("WARN", "ERROR"):
+        return {"type": "error", "content": msg}
+
+    # Model / API events
+    if "models cache" in msg or "cache hit" in msg or "cache entry" in msg:
+        return None  # skip noise
+
+    # Generic info from stream_events_utils (responses, completions)
+    if any(kw in msg for kw in ("TextDelta", "response", "completion", "output")):
+        return {"type": "response", "content": msg}
+
+    # Fallback: include as info if the message is substantial
+    if len(msg) > 10:
+        return {"type": "info", "content": msg}
+
+    return None
+
+
+@app.route("/conversation", methods=["GET"])
+def get_conversation():
+    """Return parsed conversation events from Codex logs.
+
+    Query params:
+      thread_id  - specific thread to query (optional; defaults to most recent)
+    """
+    thread_id = request.args.get("thread_id")
+
+    # Resolve thread_id from state DB if not provided
+    if not thread_id:
+        if STATE_DB.exists():
+            try:
+                conn = sqlite3.connect(
+                    f"file:{STATE_DB}?mode=ro", uri=True, timeout=3
+                )
+                row = conn.execute(
+                    "SELECT id FROM threads WHERE archived = 0 "
+                    "ORDER BY updated_at DESC LIMIT 1"
+                ).fetchone()
+                conn.close()
+                if row:
+                    thread_id = row[0]
+            except (sqlite3.Error, OSError):
+                pass
+
+    if not thread_id:
+        return jsonify([])
+
+    # Query logs for this thread
+    if not LOGS_DB.exists():
+        return jsonify([])
+
+    try:
+        conn = sqlite3.connect(
+            f"file:{LOGS_DB}?mode=ro", uri=True, timeout=3
+        )
+        rows = conn.execute(
+            "SELECT ts, level, target, feedback_log_body "
+            "FROM logs "
+            "WHERE thread_id = ? AND feedback_log_body IS NOT NULL "
+            "ORDER BY ts DESC, id DESC "
+            "LIMIT 200",
+            (thread_id,),
+        ).fetchall()
+        conn.close()
+    except (sqlite3.Error, OSError) as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    entries = []
+    for ts, level, target, body in rows:
+        parsed = _parse_log_body(body, level)
+        if parsed is None:
+            continue
+        entries.append(
+            {
+                "time": time.strftime("%H:%M:%S", time.localtime(ts)),
+                "type": parsed["type"],
+                "content": parsed["content"],
+                "level": level,
+            }
+        )
+        if len(entries) >= 50:
+            break
+
+    return jsonify(entries)
 
 
 if __name__ == "__main__":

--- a/frontend/game.js
+++ b/frontend/game.js
@@ -1551,6 +1551,100 @@ async function focusAgent(agentId) {
 }
 
 // ========================================
+// Conversation History Panel
+// ========================================
+
+let conversationVisible = false;
+let conversationPollTimer = null;
+
+function toggleConversation() {
+  conversationVisible = !conversationVisible;
+  const panel = document.getElementById('conversation-panel');
+  const btn = document.getElementById('conv-toggle');
+
+  if (panel) {
+    panel.style.display = conversationVisible ? 'flex' : 'none';
+  }
+  if (btn) {
+    btn.classList.toggle('active', conversationVisible);
+  }
+
+  if (conversationVisible) {
+    pollConversation();
+    if (!conversationPollTimer) {
+      conversationPollTimer = setInterval(pollConversation, 5000);
+    }
+  } else {
+    if (conversationPollTimer) {
+      clearInterval(conversationPollTimer);
+      conversationPollTimer = null;
+    }
+  }
+}
+
+async function pollConversation() {
+  if (!conversationVisible) return;
+  try {
+    const res = await fetch('http://localhost:19000/conversation');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (Array.isArray(data)) {
+      updateConversation(data);
+    }
+  } catch (e) {
+    // Server not reachable
+  }
+}
+
+function updateConversation(data) {
+  const el = document.getElementById('conversation-list');
+  if (!el) return;
+
+  if (!data || data.length === 0) {
+    el.innerHTML = '<div class="empty-state">No conversation data.<br>Start a Codex session to see events here.</div>';
+    return;
+  }
+
+  const typeLabels = {
+    tool: 'Tool',
+    response: 'Response',
+    user: 'User',
+    error: 'Error',
+    info: 'Info',
+  };
+
+  el.innerHTML = data.map((entry, i) => {
+    const typeClass = `conv-type-${entry.type || 'info'}`;
+    const label = typeLabels[entry.type] || 'Info';
+    const content = escapeHtml(entry.content || '');
+    const needsCollapse = content.length > 120;
+    const collapseClass = needsCollapse ? ' collapsed' : '';
+
+    return `
+      <div class="conv-entry ${typeClass}${collapseClass}" onclick="toggleConvEntry(this)">
+        <div class="conv-entry-header">
+          <span class="conv-time">${entry.time || ''}</span>
+          <span class="conv-type-badge">${label}</span>
+        </div>
+        <div class="conv-content">${content}</div>
+        ${needsCollapse ? '<div class="conv-expand-hint">Click to expand</div>' : ''}
+      </div>`;
+  }).join('');
+}
+
+function toggleConvEntry(el) {
+  if (el) {
+    el.classList.toggle('collapsed');
+  }
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+// ========================================
 // Initialize Phaser
 // ========================================
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
       <span>Thinking: <span class="stat-value" id="stat-thinking">0</span></span>
       <span>Idle: <span class="stat-value" id="stat-idle">0</span></span>
       <span>Sub: <span class="stat-value" id="stat-subagents">0</span></span>
+      <button id="conv-toggle" onclick="toggleConversation()">Chat</button>
     </div>
   </div>
 
@@ -56,6 +57,12 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- Conversation History Panel -->
+  <div id="conversation-panel" style="display:none">
+    <div class="panel-header">Conversation <button onclick="toggleConversation()" style="float:right;background:none;border:none;color:#8b949e;cursor:pointer">&#10005;</button></div>
+    <div id="conversation-list"></div>
   </div>
 
   <!-- Phaser 3 (CDN, no build step) -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -379,3 +379,120 @@ body {
   font-weight: 400;
   margin-left: 4px;
 }
+
+/* ========================================
+   Conversation History Panel
+   ======================================== */
+
+#conv-toggle {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #e6edf3;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  margin-left: 8px;
+}
+
+#conv-toggle:hover {
+  background: #30363d;
+  border-color: #484f58;
+}
+
+#conv-toggle.active {
+  background: #10a37f22;
+  border-color: #10a37f;
+  color: #10a37f;
+}
+
+#conversation-panel {
+  position: fixed;
+  top: 44px;
+  right: 0;
+  width: 400px;
+  height: calc(100vh - 44px);
+  background: #0d1117;
+  border-left: 1px solid #30363d;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#conversation-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.conv-entry {
+  padding: 8px 12px;
+  border-bottom: 1px solid #21262d;
+  font-size: 11px;
+  line-height: 1.5;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.conv-entry:hover {
+  background: #161b22;
+}
+
+.conv-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.conv-time {
+  font-size: 10px;
+  color: #484f58;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.conv-type-badge {
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.conv-type-tool .conv-type-badge   { background: #d2992222; color: #d29922; }
+.conv-type-response .conv-type-badge { background: #3fb95022; color: #3fb950; }
+.conv-type-user .conv-type-badge   { background: #1f6feb22; color: #58a6ff; }
+.conv-type-error .conv-type-badge  { background: #f8514922; color: #f85149; }
+.conv-type-info .conv-type-badge   { background: #8b949e22; color: #8b949e; }
+
+.conv-content {
+  color: #c9d1d9;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 11px;
+}
+
+.conv-entry.collapsed .conv-content {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 1.5em;
+}
+
+.conv-entry .conv-expand-hint {
+  font-size: 9px;
+  color: #484f58;
+  margin-top: 2px;
+  display: none;
+}
+
+.conv-entry.collapsed .conv-expand-hint {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- `GET /conversation` endpoint parses Codex logs from SQLite
- Toggleable chat panel (400px overlay) with type-coded entries
- Color-coded badges: tool (amber), response (green), user (cyan), error (red)
- Click to expand long entries, XSS-safe rendering
- Polls every 5s only when panel is visible

Closes #4