### PR TITLE
Add context window utilization visualization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import re
+import sqlite3
 import subprocess
 import time
 from flask import Flask, jsonify, request, send_from_directory
@@ -214,6 +216,61 @@ def git_status():
         return jsonify({"error": "Git not found"}), 500
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@app.route("/context-usage", methods=["GET"])
+def context_usage():
+    """Return context window utilization for the most recent active thread."""
+    home = os.path.expanduser("~")
+    db_path = os.path.join(home, ".codex", "state_5.sqlite")
+    config_path = os.path.join(home, ".codex", "config.toml")
+
+    # Defaults
+    context_window = 1000000
+    compact_limit = 900000
+
+    # Try to read context_window from config.toml
+    try:
+        with open(config_path, "r") as f:
+            for line in f:
+                m = re.match(r"^\s*model_context_window\s*=\s*(\d+)", line)
+                if m:
+                    context_window = int(m.group(1))
+                m2 = re.match(r"^\s*model_auto_compact_token_limit\s*=\s*(\d+)", line)
+                if m2:
+                    compact_limit = int(m2.group(1))
+    except Exception:
+        pass
+
+    # Read tokens_used from the most recent non-archived thread
+    tokens_used = 0
+    thread_title = ""
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT tokens_used, title FROM threads "
+            "WHERE archived = 0 OR archived IS NULL "
+            "ORDER BY updated_at DESC LIMIT 1"
+        )
+        row = cursor.fetchone()
+        if row:
+            tokens_used = row["tokens_used"] or 0
+            thread_title = row["title"] or ""
+        conn.close()
+    except Exception:
+        pass
+
+    percentage = round((tokens_used / context_window) * 100, 1) if context_window > 0 else 0
+
+    return jsonify({
+        "tokens_used": tokens_used,
+        "context_window": context_window,
+        "compact_limit": compact_limit,
+        "percentage": percentage,
+        "thread_title": thread_title,
+    })
 
 
 if __name__ == "__main__":

--- a/frontend/game.js
+++ b/frontend/game.js
@@ -19,6 +19,7 @@ class OfficeScene extends Phaser.Scene {
     this.elevatorDoors = null; // { left, right, light, open }
     this.elevatorBusy = false; // lock to serialize elevator usage
     this.elevatorQueue = [];   // queued callbacks waiting for elevator
+    this.contextMeter = null;  // context window gauge refs
   }
 
   create() {
@@ -56,6 +57,15 @@ class OfficeScene extends Phaser.Scene {
     this.gitPollTimer = this.time.addEvent({
       delay: 15000,
       callback: this.pollGitStatus,
+      callbackScope: this,
+      loop: true,
+    });
+
+    // Start context usage polling (every 10s)
+    this.pollContextUsage();
+    this.contextPollTimer = this.time.addEvent({
+      delay: 10000,
+      callback: this.pollContextUsage,
       callbackScope: this,
       loop: true,
     });
@@ -146,6 +156,7 @@ class OfficeScene extends Phaser.Scene {
     this.drawPlants(g);
     this.drawElevator();
     this.drawPosters(g);
+    this.drawContextMeter();
     this.drawZoneLabels();
   }
 
@@ -664,6 +675,165 @@ class OfficeScene extends Phaser.Scene {
         fontSize: '6px', fontFamily: 'monospace', color: '#0d1117',
       }).setOrigin(0.5, 0.5).setDepth(DEPTH.furnitureBg + 1);
     });
+  }
+
+  drawContextMeter() {
+    const cm = FURNITURE.contextMeter;
+    const mg = this.add.graphics();
+    mg.setDepth(DEPTH.furnitureBg + 1);
+
+    // Outer frame (dark border)
+    mg.fillStyle(0x21262d);
+    mg.fillRect(cm.x - 2, cm.y - 2, cm.w + 4, cm.h + 4);
+
+    // Inner background (empty meter area)
+    mg.fillStyle(0x0d1117);
+    mg.fillRect(cm.x, cm.y, cm.w, cm.h);
+
+    // Tick marks on the side
+    mg.lineStyle(1, 0x484f58, 0.5);
+    for (let i = 0; i <= 4; i++) {
+      const tickY = cm.y + cm.h - (i / 4) * cm.h;
+      mg.lineBetween(cm.x - 2, tickY, cm.x, tickY);
+      mg.lineBetween(cm.x + cm.w, tickY, cm.x + cm.w + 2, tickY);
+    }
+
+    // Compact limit marker (dashed line at 90%)
+    const compactY = cm.y + cm.h - 0.9 * cm.h;
+    mg.lineStyle(1, 0xd29922, 0.6);
+    for (let dx = 0; dx < cm.w; dx += 4) {
+      mg.lineBetween(cm.x + dx, compactY, cm.x + dx + 2, compactY);
+    }
+
+    // Fill bar (starts empty, will be updated)
+    const fill = this.add.graphics();
+    fill.setDepth(DEPTH.furnitureBg + 2);
+
+    // Percentage text above meter
+    const pctText = this.add.text(cm.x + cm.w / 2, cm.y - 12, '0%', {
+      fontSize: '9px',
+      fontFamily: 'monospace',
+      color: '#3fb950',
+      fontStyle: 'bold',
+    }).setOrigin(0.5, 0.5).setDepth(DEPTH.furnitureBg + 2);
+
+    // "CONTEXT" label below meter
+    this.add.text(cm.x + cm.w / 2, cm.y + cm.h + 12, 'CONTEXT', {
+      fontSize: '7px',
+      fontFamily: 'monospace',
+      color: '#6e7681',
+      letterSpacing: 1,
+    }).setOrigin(0.5, 0.5).setDepth(DEPTH.furnitureBg + 1);
+
+    // Token count text below label
+    const tokenText = this.add.text(cm.x + cm.w / 2, cm.y + cm.h + 24, '0 / 1M', {
+      fontSize: '6px',
+      fontFamily: 'monospace',
+      color: '#484f58',
+    }).setOrigin(0.5, 0.5).setDepth(DEPTH.furnitureBg + 1);
+
+    // Store references
+    this.contextMeter = {
+      fill,
+      pctText,
+      tokenText,
+      x: cm.x,
+      y: cm.y,
+      w: cm.w,
+      h: cm.h,
+      currentPct: 0,
+      glowEffect: null,
+    };
+  }
+
+  async pollContextUsage() {
+    try {
+      const res = await fetch('http://localhost:19000/context-usage');
+      if (!res.ok) return;
+      const data = await res.json();
+      this.updateContextMeter(data);
+    } catch (e) {
+      // Server not running or endpoint unavailable, silently ignore
+    }
+  }
+
+  updateContextMeter(data) {
+    const meter = this.contextMeter;
+    if (!meter) return;
+
+    const pct = Math.min(data.percentage || 0, 100);
+    const tokensUsed = data.tokens_used || 0;
+    const contextWindow = data.context_window || 1000000;
+
+    // Determine color based on percentage thresholds
+    let color;
+    let colorHex;
+    if (pct <= 50) {
+      color = 0x3fb950; colorHex = '#3fb950'; // green
+    } else if (pct <= 75) {
+      color = 0xd29922; colorHex = '#d29922'; // yellow
+    } else if (pct <= 90) {
+      color = 0xdb6d28; colorHex = '#db6d28'; // orange
+    } else {
+      color = 0xf85149; colorHex = '#f85149'; // red
+    }
+
+    // Animate fill level
+    const targetH = (pct / 100) * meter.h;
+    const targetY = meter.y + meter.h - targetH;
+
+    // Use a tween on a dummy object to animate the fill redraw
+    const tweenTarget = { fillH: (meter.currentPct / 100) * meter.h };
+    this.tweens.add({
+      targets: tweenTarget,
+      fillH: targetH,
+      duration: 600,
+      ease: 'Power2',
+      onUpdate: () => {
+        meter.fill.clear();
+        meter.fill.fillStyle(color, 0.85);
+        const currentH = tweenTarget.fillH;
+        const currentY = meter.y + meter.h - currentH;
+        meter.fill.fillRect(meter.x + 1, currentY, meter.w - 2, currentH);
+
+        // Glossy highlight
+        meter.fill.fillStyle(0xffffff, 0.08);
+        meter.fill.fillRect(meter.x + 2, currentY, 4, currentH);
+      },
+    });
+    meter.currentPct = pct;
+
+    // Update text
+    const formatTokens = (n) => {
+      if (n >= 1000000) return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
+      if (n >= 1000) return Math.round(n / 1000) + 'K';
+      return String(n);
+    };
+    meter.pctText.setText(Math.round(pct) + '%');
+    meter.pctText.setColor(colorHex);
+    meter.tokenText.setText(formatTokens(tokensUsed) + ' / ' + formatTokens(contextWindow));
+
+    // Pulsing red glow when > 90%
+    if (pct > 90 && !meter.glowEffect) {
+      const glow = this.add.graphics();
+      glow.setDepth(DEPTH.furnitureBg + 3);
+      glow.fillStyle(0xf85149, 0.15);
+      glow.fillRect(meter.x - 4, meter.y - 4, meter.w + 8, meter.h + 8);
+      meter.glowEffect = glow;
+
+      this.tweens.add({
+        targets: glow,
+        alpha: 0.3,
+        duration: 600,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+    } else if (pct <= 90 && meter.glowEffect) {
+      // Remove glow effect when back under threshold
+      meter.glowEffect.destroy();
+      meter.glowEffect = null;
+    }
   }
 
   drawZoneLabels() {

--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -137,6 +137,7 @@ const FURNITURE = {
   window: { x: 100, y: 80, w: 240, h: 120 },
   clock: { x: 780, y: 100 },
   door: { x: 830, y: 600 },
+  contextMeter: { x: 1080, y: 260, w: 30, h: 80 },
 };
 
 // Depth layers


### PR DESCRIPTION
## Summary
- `GET /context-usage` endpoint reads tokens_used from SQLite + config.toml
- Vertical gauge meter on office wall near server rack
- Color gradient: green → yellow → orange → red by percentage
- Pulsing glow effect above 90%
- Polls every 10s with animated fill transitions

Closes #5