### PR TITLE
Visualize MCP tool usage with icons above agents

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -457,6 +457,82 @@ def get_whiteboard():
     })
 
 
+@app.route("/mcp-activity", methods=["GET"])
+def mcp_activity():
+    """Return per-agent MCP tool activity and overall MCP usage stats."""
+    MCP_PATTERN = re.compile(r'ToolCall:\s*mcp__(\w+)__(\w+)')
+
+    # Find most recent active thread
+    thread_id = None
+    if STATE_DB.exists():
+        try:
+            conn = sqlite3.connect(
+                f"file:{STATE_DB}?mode=ro", uri=True, timeout=3
+            )
+            row = conn.execute(
+                "SELECT id FROM threads WHERE archived = 0 "
+                "ORDER BY updated_at DESC LIMIT 1"
+            ).fetchone()
+            conn.close()
+            if row:
+                thread_id = row[0]
+        except (sqlite3.Error, OSError):
+            pass
+
+    if not thread_id or not LOGS_DB.exists():
+        return jsonify({"active": {}, "usage": {}})
+
+    # Query last 200 log entries for MCP usage counts
+    try:
+        conn = sqlite3.connect(
+            f"file:{LOGS_DB}?mode=ro", uri=True, timeout=3
+        )
+        rows = conn.execute(
+            "SELECT ts, level, target, feedback_log_body, thread_id "
+            "FROM logs "
+            "WHERE thread_id = ? AND feedback_log_body IS NOT NULL "
+            "ORDER BY ts DESC, id DESC "
+            "LIMIT 200",
+            (thread_id,),
+        ).fetchall()
+        conn.close()
+    except (sqlite3.Error, OSError) as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    now = time.time()
+    active = {}
+    usage = {}
+
+    for ts, level, target, body, row_thread_id in rows:
+        if not body:
+            continue
+        match = MCP_PATTERN.search(body)
+        if not match:
+            continue
+
+        service = match.group(1)
+        method = match.group(2)
+
+        # Count all MCP calls for usage stats
+        usage[service] = usage.get(service, 0) + 1
+
+        # Track active MCP calls (last 30 seconds only)
+        if now - ts <= 30:
+            agent_key = row_thread_id if row_thread_id else "main"
+            # Keep only the most recent call per agent
+            if agent_key not in active:
+                active[agent_key] = {
+                    "service": service,
+                    "method": method,
+                    "timestamp": ts,
+                }
+
+    # Sort usage by count descending
+    usage = dict(sorted(usage.items(), key=lambda x: x[1], reverse=True))
+
+    return jsonify({"active": active, "usage": usage})
+
+
 @app.route("/context-usage", methods=["GET"])
 def context_usage():
     """Return context window utilization for the most recent active thread."""

--- a/frontend/game.js
+++ b/frontend/game.js
@@ -78,6 +78,15 @@ class OfficeScene extends Phaser.Scene {
       callbackScope: this,
       loop: true,
     });
+
+    // Start MCP activity polling (every 3s)
+    this.pollMCPActivity();
+    this.mcpPollTimer = this.time.addEvent({
+      delay: 3000,
+      callback: this.pollMCPActivity,
+      callbackScope: this,
+      loop: true,
+    });
   }
 
   update(time) {
@@ -992,6 +1001,9 @@ class OfficeScene extends Phaser.Scene {
       isSubagent: agentData.is_subagent || false,
       nickname: agentData.nickname || '',
       agentRole: agentData.agent_role || '',
+      mcpBadge: null,
+      mcpService: null,
+      mcpTimeout: null,
     };
 
     if (agent.isSubagent) {
@@ -1090,6 +1102,14 @@ class OfficeScene extends Phaser.Scene {
             await this.closeElevator();
 
             // 5. Destroy agent sprites now that they are hidden
+            if (agent.mcpBadge) {
+              agent.mcpBadge.destroy();
+              agent.mcpBadge = null;
+            }
+            if (agent.mcpTimeout) {
+              clearTimeout(agent.mcpTimeout);
+              agent.mcpTimeout = null;
+            }
             agent.sprite.destroy();
             agent.nameTag.destroy();
             if (agent.bubble) {
@@ -1292,6 +1312,11 @@ class OfficeScene extends Phaser.Scene {
         agent.walkTimer = 0;
         agent.sprite.setFrame(agent.sprite.frame.name === 5 ? 0 : 5);
       }
+    }
+
+    // Update MCP badge position to follow the character
+    if (agent.mcpBadge) {
+      agent.mcpBadge.setPosition(agent.sprite.x, agent.sprite.y - 58);
     }
 
     // Periodic random bubbles
@@ -1505,6 +1530,69 @@ class OfficeScene extends Phaser.Scene {
   }
 
   // ========================================
+  // MCP Activity Polling
+  // ========================================
+
+  async pollMCPActivity() {
+    try {
+      const res = await fetch('http://localhost:19000/mcp-activity');
+      if (!res.ok) return;
+      const data = await res.json();
+      // data is expected to be an object mapping agentId -> { service, timestamp }
+      // or an array of { agent_id, service, timestamp }
+      const mcpMap = {};
+      if (Array.isArray(data)) {
+        data.forEach(entry => {
+          mcpMap[entry.agent_id] = entry;
+        });
+      } else if (data && typeof data === 'object') {
+        Object.assign(mcpMap, data);
+      }
+
+      const now = Date.now();
+
+      Object.values(this.agents).forEach(agent => {
+        const mcpEntry = mcpMap[agent.id];
+        if (mcpEntry && mcpEntry.service) {
+          const serviceName = mcpEntry.service;
+          // Agent has active MCP activity
+          if (!agent.mcpBadge || agent.mcpService !== serviceName) {
+            // Remove old badge if service changed
+            if (agent.mcpBadge) {
+              MCPIcons.removeBadge(this, agent.mcpBadge);
+              agent.mcpBadge = null;
+            }
+            // Create new badge
+            agent.mcpBadge = MCPIcons.createBadge(
+              this,
+              agent.sprite.x,
+              agent.sprite.y - 58,
+              serviceName
+            );
+            agent.mcpService = serviceName;
+          }
+          // Reset timeout since activity is still active
+          if (agent.mcpTimeout) {
+            clearTimeout(agent.mcpTimeout);
+            agent.mcpTimeout = null;
+          }
+          // Set a timeout to remove badge if no further activity
+          agent.mcpTimeout = setTimeout(() => {
+            if (agent.mcpBadge) {
+              MCPIcons.removeBadge(this, agent.mcpBadge);
+              agent.mcpBadge = null;
+              agent.mcpService = null;
+            }
+            agent.mcpTimeout = null;
+          }, 5000);
+        }
+      });
+    } catch (e) {
+      // Server not running or endpoint unavailable, silently ignore
+    }
+  }
+
+  // ========================================
   // Backend Polling & UI
   // ========================================
 
@@ -1620,6 +1708,13 @@ class OfficeScene extends Phaser.Scene {
       const cardClass = isSub ? 'agent-card sub-agent' : 'agent-card';
       const displayName = isSub ? (a.nickname || a.id) : a.id;
       const roleTag = isSub && a.agent_role ? `<span class="agent-role">${a.agent_role}</span>` : '';
+      // MCP badge for sidebar
+      let mcpTag = '';
+      const agentObj = this.agents[a.id];
+      if (agentObj && agentObj.mcpService) {
+        const svc = MCPIcons.getService(agentObj.mcpService);
+        mcpTag = `<span class="mcp-badge" style="background:${svc.bg};color:${svc.color}">${svc.icon}</span>`;
+      }
       return `
         <div class="${cardClass}" ondblclick="focusAgent('${a.id}')">
           <div class="avatar" style="background:${color}">${a.id.slice(-2).toUpperCase()}</div>
@@ -1627,7 +1722,7 @@ class OfficeScene extends Phaser.Scene {
             <div class="name">${displayName}${roleTag}</div>
             <div class="task">${a.task || 'No active task'}</div>
           </div>
-          <span class="state-badge state-${a.state}">${a.state}</span>
+          <span class="state-badge state-${a.state}">${a.state}</span>${mcpTag}
         </div>
       `;
     };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,6 +89,7 @@
   <script src="sprites.js"></script>
   <script src="pathfinding.js"></script>
   <script src="whiteboard.js"></script>
+  <script src="mcp-icons.js"></script>
   <script src="game.js"></script>
 </body>
 </html>

--- a/frontend/mcp-icons.js
+++ b/frontend/mcp-icons.js
@@ -1,0 +1,74 @@
+const MCPIcons = {
+  // Known MCP services with their display properties
+  services: {
+    notion:           { label: 'Notion',    color: '#000000', bg: '#ffffff', icon: 'N' },
+    github:           { label: 'GitHub',    color: '#ffffff', bg: '#24292e', icon: 'GH' },
+    sentry:           { label: 'Sentry',    color: '#ffffff', bg: '#362d59', icon: 'S' },
+    slack:            { label: 'Slack',     color: '#ffffff', bg: '#4a154b', icon: 'SL' },
+    'chrome-devtools':{ label: 'Chrome',    color: '#000000', bg: '#fdd835', icon: 'CD' },
+    pencil:           { label: 'Pencil',    color: '#ffffff', bg: '#e91e63', icon: 'P' },
+    telegram:         { label: 'Telegram',  color: '#ffffff', bg: '#0088cc', icon: 'TG' },
+    codex_apps:       { label: 'Apps',      color: '#ffffff', bg: '#10a37f', icon: 'CA' },
+    figma:            { label: 'Figma',     color: '#ffffff', bg: '#f24e1e', icon: 'FG' },
+    vercel:           { label: 'Vercel',    color: '#ffffff', bg: '#000000', icon: 'V' },
+    supabase:         { label: 'Supabase',  color: '#ffffff', bg: '#3ecf8e', icon: 'SB' },
+    context7:         { label: 'Context7',  color: '#ffffff', bg: '#6366f1', icon: 'C7' },
+    playwright:       { label: 'Playwright',color: '#ffffff', bg: '#2ead33', icon: 'PW' },
+    'server-memory':  { label: 'Memory',    color: '#ffffff', bg: '#8b949e', icon: 'M' },
+  },
+
+  getService(name) {
+    return this.services[name] || { label: name, color: '#ffffff', bg: '#484f58', icon: name.slice(0,2).toUpperCase() };
+  },
+
+  // Draw an MCP icon badge on a Phaser scene at position (x, y) above the character
+  createBadge(scene, x, y, serviceName) {
+    // Returns a container with: rounded rect bg + icon text
+    // Small badge: ~24x14px
+    const svc = this.getService(serviceName);
+
+    const container = scene.add.container(x, y);
+    container.setDepth(250); // above bubbles
+
+    // Background pill
+    const bg = scene.add.graphics();
+    const pillW = 28, pillH = 14;
+    bg.fillStyle(parseInt(svc.bg.replace('#',''), 16), 0.9);
+    bg.fillRoundedRect(-pillW/2, -pillH/2, pillW, pillH, 4);
+    bg.lineStyle(1, 0x30363d, 0.5);
+    bg.strokeRoundedRect(-pillW/2, -pillH/2, pillW, pillH, 4);
+    container.add(bg);
+
+    // Icon text
+    const text = scene.add.text(0, 0, svc.icon, {
+      fontSize: '7px',
+      fontFamily: 'monospace',
+      color: svc.color,
+      fontStyle: 'bold',
+    }).setOrigin(0.5, 0.5);
+    container.add(text);
+
+    // Pop-in animation
+    container.setScale(0);
+    scene.tweens.add({
+      targets: container,
+      scale: 1,
+      duration: 200,
+      ease: 'Back.easeOut',
+    });
+
+    return container;
+  },
+
+  // Fade out and destroy a badge
+  removeBadge(scene, container) {
+    if (!container) return;
+    scene.tweens.add({
+      targets: container,
+      alpha: 0,
+      scale: 0.5,
+      duration: 300,
+      onComplete: () => container.destroy(),
+    });
+  },
+};

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -583,3 +583,13 @@ body {
   flex: 1;
   display: block;
 }
+
+/* MCP Service Badge */
+.mcp-badge {
+  font-size: 8px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-weight: 700;
+  font-family: monospace;
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Summary
- `GET /mcp-activity` endpoint tracks per-agent MCP tool calls from Codex logs
- 14 known MCP services with distinct colored badges (Notion, GitHub, Sentry, Slack, Figma, etc.)
- Floating icon badge appears above character sprite on MCP tool call, auto-fades after 5s
- Sidebar agent cards also show active MCP badge
- Pop-in/fade-out animations

Closes #17