### PR TITLE
Replace polling with WebSocket for real-time agent updates

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -10,9 +10,11 @@ from pathlib import Path
 
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
+from flask_socketio import SocketIO, emit
 
 app = Flask(__name__, static_folder=None)
 CORS(app)
+socketio = SocketIO(app, cors_allowed_origins="*")
 
 AGENTS_FILE = os.path.join(os.path.dirname(__file__), "agents.json")
 STALE_TIMEOUT = 120  # seconds before auto-idle
@@ -47,6 +49,14 @@ def add_log(agent_id, state, task=""):
     activity_log.insert(0, entry)
     if len(activity_log) > MAX_LOG_ENTRIES:
         activity_log.pop()
+    broadcast_update('activity', entry)
+
+
+def broadcast_update(event_type, data=None):
+    """Push real-time update to all connected clients."""
+    if data is None:
+        data = {}
+    socketio.emit(event_type, data)
 
 
 def cleanup_stale_agents(agents):
@@ -134,6 +144,7 @@ def update_agent_state():
         add_log(agent_id, "joined", f"New agent ({state})")
 
     save_agents(agents)
+    broadcast_update('agents_updated', {"agents": load_agents()})
     return jsonify({"status": "ok"})
 
 
@@ -145,6 +156,7 @@ def agent_leave():
     agents = [a for a in agents if a["id"] != agent_id]
     save_agents(agents)
     add_log(agent_id, "left", "Process exited")
+    broadcast_update('agent_left', {"id": agent_id, "agents": load_agents()})
     return jsonify({"status": "ok"})
 
 
@@ -588,8 +600,19 @@ def context_usage():
     })
 
 
+@socketio.on('connect')
+def handle_connect():
+    # Send current state on connect
+    emit('agents_updated', {"agents": load_agents()})
+
+
+@socketio.on('request_refresh')
+def handle_refresh():
+    emit('agents_updated', {"agents": load_agents()})
+
+
 if __name__ == "__main__":
     # Initialize empty agents file
     if not os.path.exists(AGENTS_FILE):
         save_agents([])
-    app.run(host="0.0.0.0", port=19000, debug=False)
+    socketio.run(app, host="0.0.0.0", port=19000, debug=False, allow_unsafe_werkzeug=True)

--- a/frontend/game.js
+++ b/frontend/game.js
@@ -41,10 +41,65 @@ class OfficeScene extends Phaser.Scene {
     // Start ambient animations
     this.startAmbientAnimations();
 
-    // Start polling backend
+    // WebSocket connection
+    this.socket = io('http://localhost:19000', {
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionDelay: 1000,
+    });
+
+    this.socket.on('connect', () => {
+      console.log('[WS] Connected');
+    });
+
+    this.socket.on('agents_updated', (data) => {
+      if (data.agents) {
+        this.syncAgents(data.agents);
+        this.updateUI(data.agents);
+        this.updateStats(data.agents);
+      }
+    });
+
+    this.socket.on('agent_left', (data) => {
+      if (data.agents) {
+        this.syncAgents(data.agents);
+        this.updateUI(data.agents);
+        this.updateStats(data.agents);
+      }
+    });
+
+    this.socket.on('activity', (entry) => {
+      // Prepend to activity log
+      const el = document.getElementById('activity-log');
+      if (el) {
+        const emptyState = el.querySelector('.empty-state');
+        if (emptyState) emptyState.remove();
+        const div = document.createElement('div');
+        div.className = 'log-entry';
+        div.innerHTML = `
+            <span class="log-time">${entry.time}</span>
+            <span class="log-agent">${entry.agent_id}</span>
+            <span class="log-state state-badge state-${entry.state}">${entry.state}</span>
+            <span class="log-task">${entry.task || ''}</span>
+        `;
+        el.prepend(div);
+        // Keep max 50 entries
+        while (el.children.length > 50) el.removeChild(el.lastChild);
+      }
+    });
+
+    this.socket.on('disconnect', () => {
+      console.log('[WS] Disconnected, falling back to polling');
+    });
+
+    // Start polling backend (fallback when WebSocket is disconnected)
     this.pollTimer = this.time.addEvent({
-      delay: 500,
-      callback: this.pollAgents,
+      delay: 2000,
+      callback: () => {
+        if (!this.socket || !this.socket.connected) {
+          this.pollAgents();
+        }
+      },
       callbackScope: this,
       loop: true,
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,6 +83,8 @@
 
   <!-- Phaser 3 (CDN, no build step) -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.80.1/dist/phaser.min.js"></script>
+  <!-- Socket.IO client for real-time updates -->
+  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 
   <!-- Our scripts (order matters) -->
   <script src="layout.js"></script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=3.0
 flask-cors>=4.0
+flask-socketio>=5.3


### PR DESCRIPTION
## Summary
- Add flask-socketio for server-side WebSocket support
- Broadcast agent state changes and activity log instantly via WebSocket
- Frontend receives updates in real-time, falls back to 2s polling if disconnected
- All REST endpoints preserved for watcher/CLI compatibility
- Socket.IO 4.7.5 client loaded from CDN

Closes #2